### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node app.js"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # BestBuy-Monitor
 
+[![Run on Repl.it](https://repl.it/badge/github/Neguhs/BestBuy-Monitor)](https://repl.it/github/Neguhs/BestBuy-Monitor)
 
 ![Nintendo-Switch](https://pisces.bbystatic.com/image2/BestBuy_US/images/products/6364/6364255_sa.jpg;maxHeight=640;maxWidth=550)
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).